### PR TITLE
Improve message formatting

### DIFF
--- a/matrix-client-modes.el
+++ b/matrix-client-modes.el
@@ -51,5 +51,19 @@
   "Face for chat metadata properties."
   :group 'matrix-client-faces)
 
+(defface matrix-client-own-metadata
+  '((((class color) (background light)) (:foreground "#268bd2" :weight bold))
+    (((class color) (background dark)) (:foreground "#268bd2" :weight bold))
+    (t (:weight bold)))
+  "Face for user's own chat metadata properties."
+  :group 'matrix-client-faces)
+
+(defface matrix-client-own-messages
+  '((((class color) (background light)) (:foreground "#586e75" :weight bold :slant italic))
+    (((class color) (background dark)) (:foreground "#586e75" :weight bold :slant italic))
+    (t (:weight bold :slant italic)))
+  "Face for user's own chat messages."
+  :group 'matrix-client-faces)
+
 (provide 'matrix-client-modes)
 ;;; matrix-client-modes.el ends here

--- a/matrix-helpers.el
+++ b/matrix-helpers.el
@@ -29,6 +29,29 @@
 
 ;;; Code:
 
+;;;; Macros
+
+(defmacro oref* (&rest slots)
+  "Access SLOTS of nested EIEIO objects.
+The first of SLOTS should be an object, while the rest should be
+slot symbols.  Accessing each slot should return an object for
+which the next slot is valid, except for the last slot, which may
+return any value."
+  (cl-labels ((rec (slots)
+                   `(oref ,(if (and (consp (cdr slots))
+                                    (cddr slots))
+                               (rec (cdr slots))
+                             (cadr slots))
+                          ,(car slots))))
+    (rec (nreverse slots))))
+
+(defmacro stringq++ (target new)
+  "Concat NEW string onto the end of TARGET string.
+TARGET is modified in-place.  Symbols should not be quoted."
+  `(setq ,target (concat ,target ,new)))
+
+;;;; Functions
+
 (defun matrix-homeserver-api-url (&optional version)
   "Message `matrix-homeserver-base-url' in to a fully-qualified API endpoint URL."
   (let ((version (or version "api/v1")))


### PR DESCRIPTION
Hey Jay,

My turn to submit PRs to you!  :)

I just started using Matrix, and I'm very glad that this package still works.  Here is a PR that makes your own messages look different from other users' messages.

I don't necessarily expect you to accept this PR as-is, mainly because of the new macros.  I didn't namespace them because the package already defines a non-namespaced macro, `insert-read-only`.  But to be good MELPA "citizens," we should probably namespace them.  

On the other hand, I searched Google and don't find any mention of "oref*" or "stringq++" macros, so maybe they would be safe.  I recently had a PR merged for `ht-get*` that does the same thing as `oref*` but for hash-tables, so the name seems logical.

We could also eliminate the stringq++ macro entirely by rewriting some of the code in `defmatrix-client-handler "m.room.message"`.  It was just a convenient way to quickly modify this code for my own use.

Also, I've started adding some text properties to the strings so that we can access them later in the buffer.  For example, I'm thinking about inserting headers when the date or hour changes, and this would make that much easier.

Well, let me know what you think.  Thanks for keeping this package alive!