### PR TITLE
Cleanup matrix client.el

### DIFF
--- a/matrix-api.el
+++ b/matrix-api.el
@@ -60,8 +60,7 @@
              :type string
              :documentation "URI to your Matrix homeserver, defaults to the official homeserver.")
    (token :initarg :token
-          :type string
-          :custom string
+          :initform nil
           :documentation "Matrix access_token")
    (txn-id :initarg :txn-id
            :initform 1
@@ -105,8 +104,7 @@ optional alist of URL parameters.  HEADERS is optional HTTP
 headers to add to the request.
 
 The return value is the `json-read' response from homeserver."
-  (let* ((token (when (slot-boundp con :token)
-                  (oref con :token)))
+  (let* ((token (oref con :token))
          (url-request-data (when content
                              (json-encode content)))
          (endpoint (concat (matrix-homeserver-api-url api-version) path))

--- a/matrix-client-handlers.el
+++ b/matrix-client-handlers.el
@@ -40,7 +40,7 @@ for each event is supported.  The handler takes a single argument,
 DATA, which is a `json-read' object from the Event stream.  See
 the Matrix spec for more information about its format."
   (add-to-list 'window-configuration-change-hook 'matrix-client-window-change-hook)
-  (unless (slot-boundp con :event-handlers)
+  (unless (oref con :event-handlers)
     (oset con :event-handlers
           '(("m.room.message" . matrix-client-handler-m.room.message)
             ("m.lightrix.pattern" . matrix-client-handler-m.lightrix.pattern)

--- a/matrix-client-handlers.el
+++ b/matrix-client-handlers.el
@@ -31,7 +31,7 @@
 
 ;;; Code:
 
-(defmethod matrix-client-handlers-init ((con matrix-client-connection))
+(cl-defmethod matrix-client-handlers-init ((con matrix-client-connection))
   "Set up all the matrix-client event type handlers.
 
 Each matrix-client-event-handler is an alist of matrix message type and
@@ -39,23 +39,23 @@ the function that handles them.  Currently only a single handler
 for each event is supported.  The handler takes a single argument,
 DATA, which is a `json-read' object from the Event stream.  See
 the Matrix spec for more information about its format."
-  (add-to-list 'window-configuration-change-hook 'matrix-client-window-change-hook)
+  ;; FIXME: `matrix-client-window-change-hook' should be renamed, and
+  ;; is currently unimplemented anyway.
+  (push 'matrix-client-window-change-hook window-configuration-change-hook)
   (unless (oref con :event-handlers)
-    (oset con :event-handlers
-          '(("m.room.message" . matrix-client-handler-m.room.message)
-            ("m.lightrix.pattern" . matrix-client-handler-m.lightrix.pattern)
-            ("m.room.topic" . matrix-client-handler-m.room.topic)
-            ("m.room.name" . matrix-client-handler-m.room.name)
-            ("m.room.member" . matrix-client-handler-m.room.member)
-            ("m.room.aliases" . matrix-client-handler-m.room.aliases)
-            ("m.presence" . matrix-client-handler-m.presence)
-            ("m.typing" . matrix-client-handler-m.typing))))
+    (oset con :event-handlers (a-list "m.room.message" 'matrix-client-handler-m.room.message
+                                      "m.lightrix.pattern" 'matrix-client-handler-m.lightrix.pattern
+                                      "m.room.topic" 'matrix-client-handler-m.room.topic
+                                      "m.room.name" 'matrix-client-handler-m.room.name
+                                      "m.room.member" 'matrix-client-handler-m.room.member
+                                      "m.room.aliases" 'matrix-client-handler-m.room.aliases
+                                      "m.presence" 'matrix-client-handler-m.presence
+                                      "m.typing" 'matrix-client-handler-m.typing)))
   (unless (oref con :input-filters)
-    (oset con :input-filters
-          '(matrix-client-input-filter-emote
-            matrix-client-input-filter-join
-            matrix-client-input-filter-leave
-            matrix-client-send-to-current-room))))
+    (oset con :input-filters '(matrix-client-input-filter-emote
+                               matrix-client-input-filter-join
+                               matrix-client-input-filter-leave
+                               matrix-client-send-to-current-room))))
 
 (defmacro defmatrix-client-handler (msgtype varlist body)
   "Create an matrix-client-handler.

--- a/matrix-client-handlers.el
+++ b/matrix-client-handlers.el
@@ -50,7 +50,7 @@ the Matrix spec for more information about its format."
             ("m.room.aliases" . matrix-client-handler-m.room.aliases)
             ("m.presence" . matrix-client-handler-m.presence)
             ("m.typing" . matrix-client-handler-m.typing))))
-  (unless (slot-boundp con :input-filters)
+  (unless (oref con :input-filters)
     (oset con :input-filters
           '(matrix-client-input-filter-emote
             matrix-client-input-filter-join

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -119,6 +119,7 @@ connection basis.")
    (end-token :initarg :end-token
               :initform nil)
    (event-handlers :initarg :event-handlers
+                   :initform nil
                    :documentation "An alist of (type . function) handler definitions for various matrix types.
 
 Each of these receives the raw event as a single DATA argument.

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -340,14 +340,13 @@ and password."
     (oset con :event-hook '(matrix-client-debug-event-maybe
                             matrix-client-render-event-to-room))))
 
-(defmethod matrix-client-debug-event-maybe ((con matrix-client-connection) room data)
+(cl-defmethod matrix-client-debug-event-maybe ((con matrix-client-connection) room data)
   "Debug DATA to *matrix-events* if `matrix-client-debug-events' is non-nil."
-  (with-current-buffer (get-buffer-create "*matrix-events*")
-    (let ((inhibit-read-only t))
-      (when matrix-client-debug-events
+  (when matrix-client-debug-events
+    (with-current-buffer (get-buffer-create "*matrix-events*")
+      (let ((inhibit-read-only t))
         (goto-char (point-max))
-        (insert "\n")
-        (insert (prin1-to-string data))))))
+        (insert "\n" (prin1-to-string data))))))
 
 (defun matrix-client-update-header-line (room)
   "Update the header line of the current buffer."

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -255,9 +255,9 @@ and password."
 
 (cl-defmethod matrix-client-start-watchdog ((con matrix-client-connection) &optional force timer-secs)
   (when (or force matrix-client-enable-watchdog)
-    (let ((last-ts (and (slot-boundp con :last-event-ts) (oref con :last-event-ts)))
-          (next (and (slot-boundp con :end-token) (oref con :end-token)))
-          (timer (and (slot-boundp con :watchdog-timer) (oref con :watchdog-timer))))
+    (let ((last-ts (oref con :last-event-ts))
+          (next (oref con :end-token))
+          (timer (oref con :watchdog-timer)))
       (if timer
           (if (> (* 1000 (- (float-time) last-ts))
                  matrix-client-event-poll-timeout)

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -156,6 +156,7 @@ event-handlers and input-filters.")
   ((con :initarg :con
         :initform nil)
    (buffer :initarg :buffer
+           :initform nil
            :documentation "The buffer that contains the room's chat session")
    (name :initarg :room-name
          :documentation "The name of the buffer's room.")
@@ -296,7 +297,7 @@ and password."
      (lambda (room-data)
        (let* ((room-id (symbol-name (car room-data)))
               (room (matrix-client-room-for-id con room-id)))
-         (when (and room (slot-boundp room :buffer))
+         (when (and room (oref room :buffer))
            (kill-buffer (oref room :buffer)))))
      (matrix-get 'leave (matrix-get 'rooms data)))
     (mapc

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -159,10 +159,13 @@ event-handlers and input-filters.")
            :initform nil
            :documentation "The buffer that contains the room's chat session")
    (name :initarg :room-name
+         :initform nil
          :documentation "The name of the buffer's room.")
    (aliases :initarg :aliases
+            :initform nil
             :documentation "The alises of the buffer's room.")
    (topic :initarg :topic
+          :initform nil
           :documentation "The topic of the buffer's room.")
    (id :initarg :id
        :initform nil
@@ -363,8 +366,8 @@ and password."
   ;; Disable when tabbar mode is on
   (unless (and (boundp 'tabbar-mode) tabbar-mode)
     (let ((typers (oref room :typers))
-          (name (and (slot-boundp room :room-name) (oref room :room-name)))
-          (topic (and (slot-boundp room :topic) (oref room :topic))))
+          (name (oref room :room-name))
+          (topic (oref room :topic)))
       (setq header-line-format (if (> 0 (length typers))
                                    (format "(%d typing...) %s: %s" (length typers) name topic)
                                  (format "%s: %s" name topic))))))

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -129,6 +129,7 @@ See `defmatrix-client-handler'.")
    (username :initarg :username
              :documentation "Your Matrix username.")
    (input-filters :initarg :input-filters
+                  :initform nil
                   :documentation "List of functions to run input through.
 
 Each of these functions take a single argument, the TEXT the user
@@ -400,7 +401,7 @@ and password."
   (let* ((room matrix-client-room-object)
          (con (when (slot-boundp room :con)
                 (oref room :con)))
-         (input-filters (and (slot-boundp con :input-filters) (oref con :input-filters))))
+         (input-filters (oref con :input-filters)))
     (cl-reduce 'matrix-client-run-through-input-filter
                input-filters
                :initial-value (pop kill-ring))))

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -380,20 +380,24 @@ and password."
 (defun matrix-client-send-active-line ()
   "Send the current message-line text after running it through input-filters."
   (interactive)
-  (let ((buffer-undo-list t))
-    (goto-char (point-max))
-    (beginning-of-line)
-    (re-search-forward "▶")
-    (forward-char)
-    (kill-line)
-    (let* ((room matrix-client-room-object)
-           (con (and (slot-boundp room :con)
-                     (oref room :con)))
-           (input-filters (and (slot-boundp con :input-filters)
-                               (oref con :input-filters))))
-      (cl-reduce 'matrix-client-run-through-input-filter
-                 input-filters
-                 :initial-value (pop kill-ring)))))
+  (goto-char (point-max))
+  (beginning-of-line)
+  ;; TODO: Make the prompt character customizable, and probably use
+  ;; text-properties or an overlay to find it.
+  (re-search-forward "▶")
+  (forward-char)
+  ;; MAYBE: Just delete the text and store it in a var instead of
+  ;; killing it to the kill-ring.  On the one hand, it's a nice
+  ;; backup, but some users might prefer not to clutter the kill-ring
+  ;; with every message they send.
+  (kill-line)
+  (let* ((room matrix-client-room-object)
+         (con (when (slot-boundp room :con)
+                (oref room :con)))
+         (input-filters (and (slot-boundp con :input-filters) (oref con :input-filters))))
+    (cl-reduce 'matrix-client-run-through-input-filter
+               input-filters
+               :initial-value (pop kill-ring))))
 
 (defun matrix-client-run-through-input-filter (text filter)
   "Run each TEXT through a single FILTER.  Used by `matrix-client-send-active-line'."

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -127,6 +127,7 @@ See `defmatrix-client-handler'.")
                :initform nil
                :documentation "A lists of functions that are evaluated when a new event comes in.")
    (username :initarg :username
+             :initform nil
              :documentation "Your Matrix username.")
    (input-filters :initarg :input-filters
                   :initform nil

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -368,9 +368,7 @@ and password."
   "Update the header line of the current buffer for ROOM."
   ;; Disable when tabbar mode is on
   (unless (and (boundp 'tabbar-mode) tabbar-mode)
-    (let ((typers (oref room :typers))
-          (name (oref room :room-name))
-          (topic (oref room :topic)))
+    (pcase-let (((eieio typers name topic) room))
       (setq header-line-format (if (> 0 (length typers))
                                    (format "(%d typing...) %s: %s" (length typers) name topic)
                                  (format "%s: %s" name topic))))))

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -173,6 +173,7 @@ event-handlers and input-filters.")
    (typers :initarg :typers
            :initform nil)
    (membership :initarg :membership
+               :initform nil
                :documentation "The list of members of the buffer's room.")
    (end-token :initarg :end-token
               :initform nil

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -401,9 +401,10 @@ and password."
 
 (defun matrix-client-run-through-input-filter (text filter)
   "Run each TEXT through a single FILTER.  Used by `matrix-client-send-active-line'."
-  (let ((con (oref matrix-client-room-object :con)))
-    (when text
-      (funcall filter con text))))
+  (when text
+    (funcall filter
+             (oref matrix-client-room-object :con)
+             text)))
 
 (defun matrix-client-send-to-current-room (con text)
   "Send a string TEXT to the current buffer's room."

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -361,6 +361,7 @@ and password."
 
 ;;;###autoload
 (defmacro insert-read-only (text &rest extra-props)
+  ;; TODO: Remove this function, and/or move it to matrix-helpers.el.
   "Insert a block of TEXT as read-only, with the ability to add EXTRA-PROPS such as face."
   `(add-text-properties
     (point) (progn
@@ -419,10 +420,12 @@ and password."
 
 (defun matrix-client-window-change-hook ()
   "Send a read receipt if necessary."
+  ;; FIXME: Unimplemented.
   ;; (when (and matrix-client-room-id matrix-client-room-end-token)
   ;;   (message "%s as read from %s" matrix-client-room-end-token matrix-client-room-id)
   ;;   (matrix-mark-as-read matrix-client-room-id matrix-client-room-end-token))
   )
 
 (provide 'matrix-client)
+
 ;;; matrix-client.el ends here

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -349,19 +349,15 @@ and password."
         (insert "\n" (prin1-to-string data))))))
 
 (defun matrix-client-update-header-line (room)
-  "Update the header line of the current buffer."
-	;; Disable when tabbar mode is on
-	(unless (and (boundp 'tabbar-mode) tabbar-mode)
-		(let ((typers (and (slot-boundp room :typers)
-										(oref room :typers)))
-					 (name (and (slot-boundp room :room-name)
-                   (oref room :room-name)))
-					 (topic (and (slot-boundp room :topic)
-                    (oref room :topic))))
-			(if (> 0 (length typers))
-        (progn
-          (setq header-line-format (format "(%d typing...) %s: %s" (length typers) name topic)))
-				(setq header-line-format (format "%s: %s" name topic))))))
+  "Update the header line of the current buffer for ROOM."
+  ;; Disable when tabbar mode is on
+  (unless (and (boundp 'tabbar-mode) tabbar-mode)
+    (let ((typers (and (slot-boundp room :typers) (oref room :typers)))
+          (name (and (slot-boundp room :room-name) (oref room :room-name)))
+          (topic (and (slot-boundp room :topic) (oref room :topic))))
+      (setq header-line-format (if (> 0 (length typers))
+                                   (format "(%d typing...) %s: %s" (length typers) name topic)
+                                 (format "%s: %s" name topic))))))
 
 ;;;###autoload
 (defmacro insert-read-only (text &rest extra-props)

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -415,8 +415,7 @@ and password."
         (id (and room
                  (slot-boundp room :id)
                  (oref room :id))))
-    (matrix-send-message con id text))
-  text)
+    (matrix-send-message con id text)))
 
 (defun matrix-client-window-change-hook ()
   "Send a read receipt if necessary."

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -368,13 +368,14 @@ and password."
               (point))
     '(read-only t ,@extra-props)))
 
-(defmethod matrix-client-render-message-line ((room matrix-client-room room))
+(cl-defmethod matrix-client-render-message-line ((room matrix-client-room room))
+  ;; FIXME: Why is there an extra "room" the arg list?  EIEIO docs
+  ;; don't seem to mention this.
   "Insert a message input at the end of the buffer."
   (goto-char (point-max))
   (let ((inhibit-read-only t))
     (insert "\n")
-    (insert-read-only "[::] ▶ " rear-nonsticky t)
-    (setq buffer-undo-list nil)))
+    (insert-read-only "[::] ▶ " rear-nonsticky t)))
 
 (defun matrix-client-send-active-line ()
   "Send the current message-line text after running it through input-filters."

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -192,9 +192,8 @@ event-handlers and input-filters.")
       (matrix-client-handlers-init con)
       (matrix-sync con nil t matrix-client-event-poll-timeout
                    (apply-partially #'matrix-client-sync-handler con))
-      (dolist (hook matrix-client-after-connect-hooks)
-        (funcall hook con)))
-    (add-to-list 'matrix-client-connections (list (oref con :username) con))
+      (run-hook-with-args 'matrix-client-after-connect-hooks con))
+    (map-put matrix-client-connections (oref con :username) con)
     (oset con :running t)
     (message "You're jacked in, welcome to Matrix. Your messages will arrive momentarily.")))
 

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -165,6 +165,7 @@ event-handlers and input-filters.")
    (topic :initarg :topic
           :documentation "The topic of the buffer's room.")
    (id :initarg :id
+       :initform nil
        :documentation "The Matrix ID of the buffer's room.")
    (typers :initarg :typers)
    (membership :initarg :membership
@@ -419,9 +420,8 @@ and password."
   (let ((room matrix-client-room-object)
         (con (when room
                (oref room :con)))
-        (id (and room
-                 (slot-boundp room :id)
-                 (oref room :id))))
+        (id (when room
+              (oref room :id))))
     (matrix-send-message con id text)))
 
 (defun matrix-client-window-change-hook ()

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -153,7 +153,8 @@ event-handlers and input-filters.")
 ;; (defvar matrix-client-event-stream-end-token nil)
 
 (defclass matrix-client-room ()
-  ((con :initarg :con)
+  ((con :initarg :con
+        :initform nil)
    (buffer :initarg :buffer
            :documentation "The buffer that contains the room's chat session")
    (name :initarg :room-name
@@ -399,8 +400,7 @@ and password."
   ;; with every message they send.
   (kill-line)
   (let* ((room matrix-client-room-object)
-         (con (when (slot-boundp room :con)
-                (oref room :con)))
+         (con (oref room :con))
          (input-filters (oref con :input-filters)))
     (cl-reduce 'matrix-client-run-through-input-filter
                input-filters
@@ -416,9 +416,8 @@ and password."
 (defun matrix-client-send-to-current-room (con text)
   "Send a string TEXT to the current buffer's room."
   (let ((room matrix-client-room-object)
-        (con (and room
-                  (slot-boundp room :con)
-                  (oref room :con)))
+        (con (when room
+               (oref room :con)))
         (id (and room
                  (slot-boundp room :id)
                  (oref room :id))))

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -180,12 +180,10 @@ event-handlers and input-filters.")
   (interactive "i")
   (let* ((base-url matrix-homeserver-base-url)
          ;; Pass a username in to get an existing connection
-         (con (when username
-                (matrix-get username matrix-client-connections)))
-         (con (unless con
-                (matrix-client-connection
-                 matrix-homeserver-base-url
-                 :base-url matrix-homeserver-base-url))))
+         (con (if username
+                  (map-elt matrix-client-connections username)
+                (matrix-client-connection matrix-homeserver-base-url
+                                          :base-url matrix-homeserver-base-url))))
     (unless (and (slot-boundp con :token) (oref con :token))
       (matrix-client-login con username))
     (unless (oref con :running)

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -334,12 +334,11 @@ and password."
              (handler (a-get (oref con :event-handlers) type)))
     (funcall handler con room item)))
 
-(defmethod matrix-client-inject-event-listeners ((con matrix-client-connection))
+(cl-defmethod matrix-client-inject-event-listeners ((con matrix-client-connection))
   "Inject the standard event listeners."
-  (unless (slot-boundp con :event-hook)
-    (oset con :event-hook
-          '(matrix-client-debug-event-maybe
-            matrix-client-render-event-to-room))))
+  (unless (and (slot-boundp con :event-hook) (oref con :event-hook))
+    (oset con :event-hook '(matrix-client-debug-event-maybe
+                            matrix-client-render-event-to-room))))
 
 (defmethod matrix-client-debug-event-maybe ((con matrix-client-connection) room data)
   "Debug DATA to *matrix-events* if `matrix-client-debug-events' is non-nil."

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -167,7 +167,8 @@ event-handlers and input-filters.")
    (id :initarg :id
        :initform nil
        :documentation "The Matrix ID of the buffer's room.")
-   (typers :initarg :typers)
+   (typers :initarg :typers
+           :initform nil)
    (membership :initarg :membership
                :documentation "The list of members of the buffer's room.")
    (end-token :initarg :end-token
@@ -361,7 +362,7 @@ and password."
   "Update the header line of the current buffer for ROOM."
   ;; Disable when tabbar mode is on
   (unless (and (boundp 'tabbar-mode) tabbar-mode)
-    (let ((typers (and (slot-boundp room :typers) (oref room :typers)))
+    (let ((typers (oref room :typers))
           (name (and (slot-boundp room :room-name) (oref room :room-name)))
           (topic (and (slot-boundp room :topic) (oref room :topic))))
       (setq header-line-format (if (> 0 (length typers))

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -318,13 +318,12 @@ and password."
       (matrix-sync con next nil matrix-client-event-poll-timeout
                    (apply-partially #'matrix-client-sync-handler con)))))
 
-(defmethod matrix-client-room-event ((room matrix-client-room) event)
+(cl-defmethod matrix-client-room-event ((room matrix-client-room) event)
   "Handle state events from a sync."
-  (let* ((con (oref room :con)))
-    (when (slot-boundp con :event-hook)
-      (mapc (lambda (hook)
-              (funcall hook con room event))
-            (oref con :event-hook)))))
+  (when-let ((con (oref room :con))
+             (fns (oref con :event-hook)))
+    (--each fns
+      (funcall it con room event))))
 
 (defmethod matrix-client-render-event-to-room ((con matrix-client-connection) room item)
   "Feed ITEM in to its proper `matrix-client-event-handlers' handler."

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -344,7 +344,7 @@ and password."
 
 (cl-defmethod matrix-client-inject-event-listeners ((con matrix-client-connection))
   "Inject the standard event listeners."
-  (unless (and (slot-boundp con :event-hook) (oref con :event-hook))
+  (unless (oref con :event-hook)
     (oset con :event-hook '(matrix-client-debug-event-maybe
                             matrix-client-render-event-to-room))))
 

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -116,13 +116,15 @@ connection basis.")
    (rooms :initarg :rooms
           :initform nil
           :documentation "List of matrix-room objects")
-   (end-token :initarg :end-token)
+   (end-token :initarg :end-token
+              :initform nil)
    (event-handlers :initarg :event-handlers
                    :documentation "An alist of (type . function) handler definitions for various matrix types.
 
 Each of these receives the raw event as a single DATA argument.
 See `defmatrix-client-handler'.")
    (event-hook :initarg :event-hook
+               :initform nil
                :documentation "A lists of functions that are evaluated when a new event comes in.")
    (username :initarg :username
              :documentation "Your Matrix username.")
@@ -132,8 +134,10 @@ See `defmatrix-client-handler'.")
 Each of these functions take a single argument, the TEXT the user
 inputs.  They can modify that text and return a new version of
 it, or they can return nil to prevent further processing of it.")
-   (watchdog-timer :initarg :watchdog-timer)
-   (last-event-ts :initarg :last-event-ts))
+   (watchdog-timer :initarg :watchdog-timer
+                   :initform nil)
+   (last-event-ts :initarg :last-event-ts
+                  :initform 0))
   :documentation "This is the basic UI encapsulation of a Matrix connection.
 
 To build a UI on top of `matrix-api' start here, wire up
@@ -163,6 +167,7 @@ event-handlers and input-filters.")
    (membership :initarg :membership
                :documentation "The list of members of the buffer's room.")
    (end-token :initarg :end-token
+              :initform nil
               :documentation "The most recent event-id in a room, used to push read-receipts to the server.")))
 
 (defvar-local matrix-client-room-typers nil

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -325,12 +325,14 @@ and password."
     (--each fns
       (funcall it con room event))))
 
-(defmethod matrix-client-render-event-to-room ((con matrix-client-connection) room item)
+(cl-defmethod matrix-client-render-event-to-room ((con matrix-client-connection) room item)
   "Feed ITEM in to its proper `matrix-client-event-handlers' handler."
-  (let* ((type (matrix-get 'type item))
-         (handler (matrix-get type (oref con :event-handlers))))
-    (when handler
-      (funcall handler con room item))))
+  ;; NOTE: It's tempting to use `map-elt' here, but it uses `eql' to
+  ;; compare keys, and since the keys are strings, that doesn't work.
+  ;; MAYBE: Perhaps we should change the keys to symbols someday...
+  (when-let ((type (a-get item 'type))
+             (handler (a-get (oref con :event-handlers) type)))
+    (funcall handler con room item)))
 
 (defmethod matrix-client-inject-event-listeners ((con matrix-client-connection))
   "Inject the standard event listeners."

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -192,7 +192,7 @@ event-handlers and input-filters.")
                   (map-elt matrix-client-connections username)
                 (matrix-client-connection matrix-homeserver-base-url
                                           :base-url matrix-homeserver-base-url))))
-    (unless (and (slot-boundp con :token) (oref con :token))
+    (unless (oref con :token)
       (matrix-client-login con username))
     (unless (oref con :running)
       (matrix-client-start-watchdog con nil 120)

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -258,7 +258,7 @@ and password."
                 (cancel-timer timer)
                 ;; XXX Pull these fucking syncs out and bar them on (oref con :running)
                 (when (oref con :running)
-                  (message "Reconnecting you to Matrix, one monent please.")
+                  (message "Reconnecting you to Matrix, one moment please...")
                   (cancel-timer timer)
                   (matrix-sync con next nil matrix-client-event-poll-timeout
                                (apply-partially #'matrix-client-sync-handler con))))

--- a/matrix-helpers.el
+++ b/matrix-helpers.el
@@ -45,6 +45,24 @@ return any value."
                           ,(car slots))))
     (rec (nreverse slots))))
 
+(defmacro oset-multi (object &rest pairs)
+  "Set slot values for OBJECT.
+PAIRS should be of the form (SLOT VALUE SLOT VALUE...)."
+  (declare (indent defun))
+  `(progn
+     ,@(cl-loop for (slot value) on pairs by #'cddr
+                collect (list 'oset object slot value))))
+
+(defmacro a-get* (&rest keys)
+  ;; See https://github.com/plexus/a.el/issues/7
+  (cl-labels ((rec (keys)
+                   `(a-get ,(if (and (consp (cdr keys))
+                                     (cddr keys))
+                                (rec (cdr keys))
+                              (cadr keys))
+                           ,(car keys))))
+    (rec (nreverse keys))))
+
 ;;;; Functions
 
 (defun matrix-homeserver-api-url (&optional version)


### PR DESCRIPTION
Hey Jay,

Here are some more cleanups.  I learned several things in the process:

* `map-elt` uses `eql` for comparison, so it does not work for alists whose keys are strings.  `a-get` works for this.  We might want to change the string keys to symbols in the future, if appropriate, but I haven't looked into it yet.
* `run-hook-with-args` requires a *symbol* as its argument, not a variable, so it doesn't work with hooks that are not in the symbol table, e.g. a list that's looked up at runtime.
* Gained more experience with git-bisect, as after making all the changes at once, the only way I could track down my mistakes was to split them up into separate commits and run bisect over, and over, and over, reordering commits and fixing mistakes as I went!  Argh!  :)  

But in the end, it works, and the code should be easier to understand now.  I may have even fixed a minor bug or two along the way.  And I'm working toward understanding how it all works, one function/file at a time.  And I've learned about EIEIO too, which I haven't used before.

Thanks.

BTW, if https://github.com/magnars/dash.el/pull/251 is merged, we can start using that to simplify some code, too. ... Actually, I just realized we can use `pcase-let` now, and it's better in this case, so I used that.