### PR TITLE
Show images

### DIFF
--- a/matrix-client.el
+++ b/matrix-client.el
@@ -7,7 +7,7 @@
 ;; Keywords: web
 ;; Homepage: http://doc.rix.si/matrix.html
 ;; Package-Version: 0.1.2
-;; Package-Requires: ((emacs "25.1") (dash "2.13.0") (json "1.4") (request "0.2.0") (a "0.1.0"))
+;; Package-Requires: ((emacs "25.1") (dash "2.13.0") (json "1.4") (request "0.2.0") (a "0.1.0") (f "0.17.2"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
This optionally (off, by default) downloads and displays images inserted into the buffer, both direct inserts through Matrix, and optionally, URLs to images posted as text.  It uses the `f` library to read and delete the temp files.  Works great so far.

Of course, it would be best to do the download async, but I think we should do a more general conversion to async across the package eventually, so we can worry about that then.  Since it's off by default, it won't be hanging Emacs on long downloads unless users turn it on.