### PR TITLE
Change: (matrix-api.el) Send messages to rooms async

### DIFF
--- a/matrix-client-handlers.el
+++ b/matrix-client-handlers.el
@@ -151,6 +151,9 @@ like."
                        (t
                         (matrix-client-linkify-urls (map-elt content 'body))))))
 
+     ;; Trim messages because HTML ones can have extra newlines
+     (setq message (string-trim message))
+
      ;; Apply face for own messages
      (let (metadata-face message-face)
        (if (string= display-name own-display-name)


### PR DESCRIPTION
I changed sending messages to rooms to use async, and it seems to work fine: Emacs returns as soon as you hit enter, and when the message gets back from the server, it shows up.