### PR TITLE
Rewrite insertion and prompt

### DIFF
--- a/matrix-client-handlers.el
+++ b/matrix-client-handlers.el
@@ -86,7 +86,7 @@ BODY is the function itself.  See, for example,
 like."
   (let ((fname (intern (format "matrix-client-handler-%s" msgtype))))
     `(defun ,fname (con room data)
-       (let* ((inhibit-read-only t)
+       (let* ((inhibit-read-only t)     ; FIXME: Can probably remove this now.
               (room-id (oref room :id))
               (room-buf (oref room :buffer))
               ,@varlist)
@@ -115,7 +115,9 @@ like."
   ((content (map-elt data 'content))
    (msg-type (map-elt content 'msgtype))
    (format (map-elt content 'format))
-   (timestamp (/ (map-elt data 'origin_server_ts) 1000))
+   ;; We don't use `matrix-client-event-data-timestamp', because for
+   ;; room messages, the origin_server_ts is the actual message time.
+   (timestamp (/ (a-get* data 'origin_server_ts) 1000))
    (sender (map-elt data 'sender))
    (display-name (matrix-client-displayname-from-user-id room (map-elt data 'sender)))
    (own-display-name (oref* room :con :username)))
@@ -148,8 +150,7 @@ like."
                                 (matrix-client-linkify-urls
                                  (matrix-transform-mxc-uri (or (map-elt content 'url)
                                                                (map-elt content 'thumbnail_url))))))
-                       (t
-                        (matrix-client-linkify-urls (map-elt content 'body))))))
+                       (_ (matrix-client-linkify-urls (map-elt content 'body))))))
 
      ;; Trim messages because HTML ones can have extra newlines
      (setq message (string-trim message))
@@ -163,23 +164,27 @@ like."
                message-face 'default))
        ;; Use 'append so that link faces are not overridden.
        (add-face-text-property 0 (length metadata) metadata-face 'append metadata)
-       (add-face-text-property 0 (length output) message-face 'append output))
-     ;; Add metadata to output
-     (setq output (concat metadata message))
-     ;; Add text properties
-     (setq output (propertize output
+       (add-face-text-property 0 (length message) message-face 'append message))
+
+     ;; Concat metadata with message and add text properties
+     (setq output (propertize (concat metadata message)
                               'timestamp timestamp
                               'display-name display-name
                               'sender sender
                               'event_id event_id))
+
      ;; Actually insert text
-     (insert-read-only "\n")
-     (insert-read-only output)
+     (matrix-client-insert room output)
 
      ;; Notification
      (unless (equal own-display-name display-name)
        (run-hook-with-args 'matrix-client-notify-hook "m.room.message" data
                            :room room)))))
+
+(defun insert-read-only (text &rest extra-props)
+  ;; NOTE: The "m.lightrix.pattern" handler is the only one that uses this now.
+  "Insert a block of TEXT as read-only, with the ability to add EXTRA-PROPS such as face."
+  (insert (apply #'propertize text 'read-only t extra-props)))
 
 (defmatrix-client-handler "m.lightrix.pattern"
   ;; FIXME: Move this to separate file for Ryan.  :)
@@ -196,52 +201,80 @@ like."
    (room-membership (oref room :membership))
    (display-name (map-elt content 'displayname)))
   ((assq-delete-all user-id room-membership)
-   (if (string= "join" membership)
-       (progn
-         (when matrix-client-render-membership
-           (insert-read-only "\n")
-           (insert-read-only (format "Joined: %s (%s) --> %s" display-name user-id membership) face matrix-client-metadata))
-         (push (cons user-id content) room-membership))
+   (let* ((timestamp (matrix-client-event-data-timestamp data))
+          (action (pcase membership
+                    ("join" (progn
+                              (push (cons user-id content) room-membership)
+                              "Joined"))
+                    ("leave" (progn
+                               ;; FIXME: Remove user from room-membership
+                               "Left"))
+                    (_ (format "Unknown membership message: %s" membership))))
+          (msg (propertize (format "%s: %s (%s)" action display-name user-id)
+                           'timestamp timestamp
+                           'face 'matrix-client-metadata)))
      (when matrix-client-render-membership
-       (insert-read-only "\n")
-       (insert-read-only (format "Left: %s (%s) --> %s" display-name user-id membership) face matrix-client-metadata)))
+       (matrix-client-insert room msg)))
    (oset room :membership room-membership)
    (matrix-client-update-name room)))
 
 (defun matrix-client-handler-m.presence (data)
   "Insert presence message into events buffer for DATA."
   (when matrix-client-render-presence
-    (let* ((inhibit-read-only t)
+    (let* ((timestamp (matrix-client-event-data-timestamp data))
            (content (map-elt data 'content))
            (user-id (map-elt content 'user_id))
            (presence (map-elt content 'presence))
            (display-name (map-elt content 'displayname)))
       (with-current-buffer (get-buffer-create "*matrix-events*")
         (goto-char (point-max))
-        (insert-read-only "\n")
-        (insert-read-only (format "%s (%s) --> %s" display-name user-id presence) face matrix-client-metadata)))))
+        (matrix-client-insert room (propertize (format "%s (%s) --> %s" display-name user-id presence)
+                                               'face 'matrix-client-metadata
+                                               'timestamp timestamp))))))
+
+(defun matrix-client-event-data-timestamp (data)
+  "Return timestamp of event DATA."
+  (let ((server-ts (float (a-get* data 'origin_server_ts)))
+        (event-age (float (a-get* data 'unsigned 'age))))
+    ;; The timestamp and the age are in milliseconds.  We need
+    ;; millisecond precision in case of two messages sent/received
+    ;; within one second, but we need to return seconds, not
+    ;; milliseconds.  So we divide by 1000 to get the timestamp in
+    ;; seconds, but we keep millisecond resolution by using floats.
+    (/ (- server-ts event-age) 1000)))
 
 (defmatrix-client-handler "m.room.name"
   ()
   ((oset room :room-name (a-get* data 'content 'name))
    (matrix-client-update-name room)
-   (insert-read-only "\n")
-   (insert-read-only (format "Room name changed --> %s" (oref room :room-name)) face matrix-client-metadata)
-   (matrix-client-update-header-line room)))
+   (matrix-client-update-header-line room)
+   (when-let ((event_id (a-get data 'event_id))
+              (timestamp (matrix-client-event-data-timestamp data))
+              (message (propertize (format "Room name changed --> %s" (oref room :room-name))
+                                   'timestamp timestamp
+                                   'event_id event_id
+                                   'face 'matrix-client-metadata)))
+     (matrix-client-insert room message))))
 
 (defmatrix-client-handler "m.room.aliases"
   ((new-alias-list (a-get* data 'content 'aliases)))
-  ((oset room :aliases new-alias-list)
+  ((let* ((timestamp (matrix-client-event-data-timestamp data))
+          (message (propertize (format "Room alias changed --> %s" new-alias-list)
+                               'timestamp timestamp
+                               'face 'matrix-client-metadata)))
+     (matrix-client-insert room message))
+   (oset room :aliases new-alias-list)
    (matrix-client-update-name room)
-   (insert-read-only "\n")
-   (insert-read-only (format "Room alias changed --> %s" new-alias-list) face matrix-client-metadata)
    (matrix-client-update-header-line room)))
 
 (defmatrix-client-handler "m.room.topic"
   ((topic (a-get* data 'content 'topic)))
-  ((oset room :topic topic)
-   (insert-read-only "\n")
-   (insert-read-only (format "Room topic changed --> %s" topic) face matrix-client-metadata)
+  ((let* ((timestamp (matrix-client-event-data-timestamp data))
+          (message (propertize (format "Room topic changed --> %s" topic)
+                               'timestamp timestamp
+                               'face 'matrix-client-metadata)))
+     (matrix-client-insert room message))
+   (oset room :topic topic)
    (matrix-client-update-header-line room)))
 
 (defun matrix-client-handler-m.typing (con room data)

--- a/matrix-client-modes.el
+++ b/matrix-client-modes.el
@@ -36,6 +36,7 @@
 (defvar matrix-client-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "RET") 'matrix-client-send-active-line)
+    (define-key map (kbd "DEL") 'matrix-client-delete-backward-char)
     map)
   "Keymap for `matrix-client-mode'.")
 

--- a/matrix-client.el
+++ b/matrix-client.el
@@ -7,7 +7,7 @@
 ;; Keywords: web
 ;; Homepage: http://doc.rix.si/matrix.html
 ;; Package-Version: 0.1.2
-;; Package-Requires: ((emacs "25.1") (dash "2.13.0") (json "1.4") (request "0.2.0") (a "0.1.0"))
+;; Package-Requires: ((emacs "25.1") (dash "2.13.0") (json "1.4") (request "0.2.0") (a "0.1.0") (ov "1.0.6"))
 
 ;; This file is not part of GNU Emacs.
 
@@ -47,6 +47,7 @@
 (require 'seq)
 
 (require 'dash)
+(require 'ov)
 
 ;;;###autoload
 (defcustom matrix-client-debug-events nil
@@ -386,6 +387,25 @@ and password."
              (handler (a-get (oref con :event-handlers) type)))
     (funcall handler con room item)))
 
+(cl-defmethod matrix-client-insert ((room matrix-client-room) string)
+  "Insert STRING into ROOM's buffer.
+STRING should have a `timestamp' text-property."
+  (let ((inhibit-read-only t)
+        (timestamp (get-text-property 0 'timestamp string)))
+    (with-current-buffer (oref room :buffer)
+      (cl-loop initially do (progn
+                              (goto-char (ov-beg (car (ov-in 'matrix-client-prompt t))))
+                              (forward-line -1))
+               for buffer-ts = (get-text-property (point) 'timestamp)
+               until (when buffer-ts
+                       (< buffer-ts timestamp))
+               while (when-let (pos (previous-single-property-change (point) 'timestamp))
+                       (goto-char pos))
+               finally do (when-let (pos (next-single-property-change (point) 'timestamp))
+                            (goto-char pos)))
+      (insert "\n"
+              (propertize string 'read-only t)))))
+
 (cl-defmethod matrix-client-inject-event-listeners ((con matrix-client-connection))
   "Inject the standard event listeners."
   (unless (oref con :event-hook)
@@ -409,34 +429,30 @@ and password."
                                    (format "(%d typing...) %s: %s" (length typers) name topic)
                                  (format "%s: %s" name topic))))))
 
-;;;###autoload
-(defmacro insert-read-only (text &rest extra-props)
-  ;; TODO: Remove this function, and/or move it to matrix-helpers.el.
-  "Insert a block of TEXT as read-only, with the ability to add EXTRA-PROPS such as face."
-  `(add-text-properties
-    (point) (progn
-              (insert ,text)
-              (point))
-    '(read-only t ,@extra-props)))
+(defvar matrix-client-input-prompt "▶ ")
 
 (cl-defmethod matrix-client-render-message-line ((room matrix-client-room room))
   ;; FIXME: Why is there an extra "room" the arg list?  EIEIO docs
   ;; don't seem to mention this.
   "Insert a message input at the end of the buffer."
   (goto-char (point-max))
-  (let ((inhibit-read-only t))
-    (insert "\n")
-    (insert-read-only "[::] ▶ " rear-nonsticky t)))
+  (let ((inhibit-read-only t)
+        (ov-sticky-front t))
+    (insert (propertize "\n" 'read-only t)
+            "\n")
+    (ov (point) (point)
+        'before-string (concat "\n" matrix-client-input-prompt)
+        'matrix-client-prompt t)))
 
 (defun matrix-client-send-active-line ()
   "Send the current message-line text after running it through input-filters."
   (interactive)
   (goto-char (point-max))
-  (beginning-of-line)
+
   ;; TODO: Make the prompt character customizable, and probably use
   ;; text-properties or an overlay to find it.
-  (re-search-forward "▶")
-  (forward-char)
+  (goto-char (ov-end (car (ov-in 'matrix-client-prompt t))))
+
   ;; MAYBE: Just delete the text and store it in a var instead of
   ;; killing it to the kill-ring.  On the one hand, it's a nice
   ;; backup, but some users might prefer not to clutter the kill-ring

--- a/matrix-helpers.el
+++ b/matrix-helpers.el
@@ -65,6 +65,18 @@ PAIRS should be of the form (SLOT VALUE SLOT VALUE...)."
 
 ;;;; Functions
 
+(defun matrix-client-buffer-list-update-hook ()
+  "Set buffer's modified status when focused."
+  (when (matrix-client-buffer-visible-p)
+    (set-buffer-modified-p nil)))
+
+(defun matrix-client-buffer-visible-p (&optional buffer)
+  "Return non-nil if BUFFER is currently visible.
+If BUFFER is nil, use the current buffer."
+  (let ((buffer (or buffer (current-buffer))))
+    (or (eq buffer (window-buffer (selected-window)))
+        (get-buffer-window buffer))))
+
 (defun matrix-client-delete-backward-char (n &optional kill-flag)
   "Delete backward unless the point is at the prompt or other read-only text."
   (interactive "p\nP")

--- a/matrix-helpers.el
+++ b/matrix-helpers.el
@@ -65,6 +65,12 @@ PAIRS should be of the form (SLOT VALUE SLOT VALUE...)."
 
 ;;;; Functions
 
+(defun matrix-client-delete-backward-char (n &optional kill-flag)
+  "Delete backward unless the point is at the prompt or other read-only text."
+  (interactive "p\nP")
+  (unless (get-text-property (- (point) 2) 'read-only)
+    (call-interactively #'delete-backward-char n kill-flag)))
+
 (defun matrix-homeserver-api-url (&optional version)
   "Message `matrix-homeserver-base-url' in to a fully-qualified API endpoint URL."
   (let ((version (or version "api/v1")))


### PR DESCRIPTION
Every string inserted into a room buffer now has a timestamp text-property.  This is used to find the correct place when inserting messages into a buffer.  This will allow us to later add code that fetches earlier messages and inserts them at the right place, as well as, perhaps, more async code here and there, because events no longer have to be received in-order to be inserted at the right place.

The prompt has also been rewritten to use an overlay and have a customizable string.  The overlay is used to find the prompt, so the string doesn't matter.