### PR TITLE
Fix: (matrix-update-room-name): Fix edge cases in room name detection

### DIFF
--- a/matrix-client-handlers.el
+++ b/matrix-client-handlers.el
@@ -226,8 +226,9 @@ Otherwise, use the room name or alias."
                                    (if (eq (current-buffer) (get-buffer username))
                                        username
                                      (generate-new-buffer-name username))))
-                                ((oref room :room-name))
-                                ((car (oref room :aliases))))))
+                           ((oref room :room-name))
+                           ((> (length (oref room :aliases)) 0)
+                            (elt (oref room :aliases) 0)))))
     (rename-buffer buffer-name)))
 
 (defun matrix-client-handler-m.presence (data)


### PR DESCRIPTION
I found a small bug preventing me from seeing all my matrix buffers (I have a **ton** of matrix buffers, so just opening it up is a pretty good test :smile:)

I think the object returned by `(oref room :aliases)` isn't a list (not sure what type it is right now), so we can't use `car` or assume it returns `nil` if empty.

Have you been able to get backtraces working when running this section of the code? I haven't been able to (it just hung for me). Maybe it's because this section gets called repeatedly in quick succession.