### PR TITLE
Fix possible crash in time calc

### DIFF
--- a/matrix-client-handlers.el
+++ b/matrix-client-handlers.el
@@ -235,7 +235,8 @@ like."
 (defun matrix-client-event-data-timestamp (data)
   "Return timestamp of event DATA."
   (let ((server-ts (float (a-get* data 'origin_server_ts)))
-        (event-age (float (a-get* data 'unsigned 'age))))
+        (event-age (float (or (a-get* data 'unsigned 'age)
+                              0))))
     ;; The timestamp and the age are in milliseconds.  We need
     ;; millisecond precision in case of two messages sent/received
     ;; within one second, but we need to return seconds, not


### PR DESCRIPTION
Missed a small issue in the last pr, which this should fix:

I got this event from the matrix server, lacking the unsigned age property, which crashed the time calculation. This prevents that from happening:

```
((content (membership . "join")) (event_id . "$144805846118506mEOHt:matrix.org") (origin_server_ts . 1448058461139) (sender . "@mrc:v42.dk") (state_key . "@mrc:v42.dk") (type . "m.room.member") (unsigned (replaces_state . "$14480584253KUGcf:v42.dk")))
```

Not sure if this is a bug in the matrix server or not, but it's good to catch this either way.