### PR TITLE
Fix incorrect logic in matrix-parse-url-exit-code

### DIFF
--- a/matrix-helpers.el
+++ b/matrix-helpers.el
@@ -106,13 +106,22 @@ If BUFFER is nil, use the current buffer."
 
 (defun matrix-parse-curl-exit-code (error-string)
   "Return exit code from ERROR-STRING as a number, or nil if none found."
-  (when (string-match "exited abnormally with code \\([[:digit:]]+\\).*" error-string)
-    (ignore-errors
-      ;; Ignore errors to avoid any problems that might be caused by
-      ;; the error string not matching.  I don't think this is
-      ;; strictly necessary, but the old code caught errors, so just
-      ;; in case...
-      (string-to-int (match-string-no-properties 1 error-string)))))
+  (cond
+   ;; If we get a list with a number, use that '(401)
+   ((and (listp error-string)
+         (> (length error-string) 0)
+         (numberp (first error-string)))
+    (first error-string))
+   ((stringp error-string)
+    (when (string-match "exited abnormally with code \\([[:digit:]]+\\).*" error-string)
+      (ignore-errors
+        ;; Ignore errors to avoid any problems that might be caused by
+        ;; the error string not matching.  I don't think this is
+        ;; strictly necessary, but the old code caught errors, so just
+        ;; in case...
+        (string-to-number (match-string-no-properties 1 error-string)))))
+   (t
+    nil)))
 
 (provide 'matrix-helpers)
 ;;; matrix-helpers.el ends here


### PR DESCRIPTION
I was trying to figure out why my stacktraces werent coming up and I finally managed to catch one (which I don't think is related to your PR's):

```
Debugger entered--Lisp error: (wrong-type-argument stringp (401))
  string-match("exited abnormally with code \\([[:digit:]]+\\).*" (401))
  (if (string-match "exited abnormally with code \\([[:digit:]]+\\).*" error-string) (progn (condition-case nil (progn (string-to-int (match-string-no-properties 1 error-string))) (error nil))))
  matrix-parse-curl-exit-code((401))
  (let ((exit-code (matrix-parse-curl-exit-code (cdr (cdr error-thrown))))) (warn (cond ((memq exit-code '(60 51)) "Error sending request to matrix homeserver, SSL certificate is invalid") ((null exit-code) "Unknown error occurred sending request to matrix homeserver: %S") (t (format "Matrix request exited with exit code %d" exit-code)))))
  (progn (let ((--dolist-tail-- matrix-error-hook) handler) (while --dolist-tail-- (setq handler (car --dolist-tail--)) (funcall handler con symbol-status error-thrown) (setq --dolist-tail-- (cdr --dolist-tail--)))) (let ((exit-code (matrix-parse-curl-exit-code (cdr (cdr error-thrown))))) (warn (cond ((memq exit-code '(60 51)) "Error sending request to matrix homeserver, SSL certificate is invalid") ((null exit-code) "Unknown error occurred sending request to matrix homeserver: %S") (t (format "Matrix request exited with exit code %d" exit-code))))))
  (let* ((error-thrown (car (cdr (plist-member args ':error-thrown)))) (symbol-status (car (cdr (plist-member args ':symbol-status))))) (progn (let ((--dolist-tail-- matrix-error-hook) handler) (while --dolist-tail-- (setq handler (car --dolist-tail--)) (funcall handler con symbol-status error-thrown) (setq --dolist-tail-- (cdr --dolist-tail--)))) (let ((exit-code (matrix-parse-curl-exit-code (cdr (cdr error-thrown))))) (warn (cond ((memq exit-code '(60 51)) "Error sending request to matrix homeserver, SSL certificate is invalid") ((null exit-code) "Unknown error occurred sending request to matrix homeserver: %S") (t (format "Matrix request exited with exit code %d" exit-code)))))))
  matrix-request-error-handler(#<matrix-client-connection matrix-client-connection> :data ((errcode . "M_MISSING_TOKEN") (error . "Missing access token.")) :symbol-status error :error-thrown (error http 401) :response #s(request-response :status-code 401 :history nil :data ((errcode . "M_MISSING_TOKEN") (error . "Missing access token.")) :error-thrown (error http 401) :symbol-status error :url "https://matrix.org/_matrix/client/r0/sync?timeout=30000&full_state=true" :done-p nil :settings (:type "GET" :params (("timeout" . "30000") ("full_state" . "true")) :parser json-read :data "null" :error #f(compiled-function (&rest args2) #<bytecode 0x1be7599>) :headers (("Content-Type" . "application/json")) :complete #f(compiled-function (&rest args2) #<bytecode 0x1becf39>) :url "https://matrix.org/_matrix/client/r0/sync?timeout=30000&full_state=true" :response #1) :-buffer #<killed buffer> :-raw-header "HTTP/1.1 401 Unauthorized\nContent-Length: 75\nAccess-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Authorization\nServer: Synapse/0.24.1 (b=matrix-org-hotfixes,7add114)\nDate: Thu, 16 Nov 2017 18:43:22 GMT\nAccess-Control-Allow-Origin: *\nAccess-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\nContent-Type: application/json\n" :-timer nil :-backend curl :-tempfiles ("/tmp/emacs-requesth7USB4")))
  apply(matrix-request-error-handler (#<matrix-client-connection matrix-client-connection> :data ((errcode . "M_MISSING_TOKEN") (error . "Missing access token.")) :symbol-status error :error-thrown (error http 401) :response #s(request-response :status-code 401 :history nil :data ((errcode . "M_MISSING_TOKEN") (error . "Missing access token.")) :error-thrown (error http 401) :symbol-status error :url "https://matrix.org/_matrix/client/r0/sync?timeout=30000&full_state=true" :done-p nil :settings (:type "GET" :params (("timeout" . "30000") ("full_state" . "true")) :parser json-read :data "null" :error #f(compiled-function (&rest args2) #<bytecode 0x1be7599>) :headers (("Content-Type" . "application/json")) :complete #f(compiled-function (&rest args2) #<bytecode 0x1becf39>) :url "https://matrix.org/_matrix/client/r0/sync?timeout=30000&full_state=true" :response #2) :-buffer #<killed buffer> :-raw-header "HTTP/1.1 401 Unauthorized\nContent-Length: 75\nAccess-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Authorization\nServer: Synapse/0.24.1 (b=matrix-org-hotfixes,7add114)\nDate: Thu, 16 Nov 2017 18:43:22 GMT\nAccess-Control-Allow-Origin: *\nAccess-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\nContent-Type: application/json\n" :-timer nil :-backend curl :-tempfiles ("/tmp/emacs-requesth7USB4"))))
  #f(compiled-function (&rest args2) #<bytecode 0x1be7599>)(:data ((errcode . "M_MISSING_TOKEN") (error . "Missing access token.")) :symbol-status error :error-thrown (error http 401) :response #s(request-response :status-code 401 :history nil :data ((errcode . "M_MISSING_TOKEN") (error . "Missing access token.")) :error-thrown (error http 401) :symbol-status error :url "https://matrix.org/_matrix/client/r0/sync?timeout=30000&full_state=true" :done-p nil :settings (:type "GET" :params (("timeout" . "30000") ("full_state" . "true")) :parser json-read :data "null" :error #f(compiled-function (&rest args2) #<bytecode 0x1be7599>) :headers (("Content-Type" . "application/json")) :complete #f(compiled-function (&rest args2) #<bytecode 0x1becf39>) :url "https://matrix.org/_matrix/client/r0/sync?timeout=30000&full_state=true" :response #1) :-buffer #<killed buffer> :-raw-header "HTTP/1.1 401 Unauthorized\nContent-Length: 75\nAccess-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Authorization\nServer: Synapse/0.24.1 (b=matrix-org-hotfixes,7add114)\nDate: Thu, 16 Nov 2017 18:43:22 GMT\nAccess-Control-Allow-Origin: *\nAccess-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\nContent-Type: application/json\n" :-timer nil :-backend curl :-tempfiles ("/tmp/emacs-requesth7USB4")))
  apply(#f(compiled-function (&rest args2) #<bytecode 0x1be7599>) (:data ((errcode . "M_MISSING_TOKEN") (error . "Missing access token.")) :symbol-status error :error-thrown (error http 401) :response #s(request-response :status-code 401 :history nil :data ((errcode . "M_MISSING_TOKEN") (error . "Missing access token.")) :error-thrown (error http 401) :symbol-status error :url "https://matrix.org/_matrix/client/r0/sync?timeout=30000&full_state=true" :done-p nil :settings (:type "GET" :params (("timeout" . "30000") ("full_state" . "true")) :parser json-read :data "null" :error #f(compiled-function (&rest args2) #<bytecode 0x1be7599>) :headers (("Content-Type" . "application/json")) :complete #f(compiled-function (&rest args2) #<bytecode 0x1becf39>) :url "https://matrix.org/_matrix/client/r0/sync?timeout=30000&full_state=true" :response #2) :-buffer #<killed buffer> :-raw-header "HTTP/1.1 401 Unauthorized\nContent-Length: 75\nAccess-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Authorization\nServer: Synapse/0.24.1 (b=matrix-org-hotfixes,7add114)\nDate: Thu, 16 Nov 2017 18:43:22 GMT\nAccess-Control-Allow-Origin: *\nAccess-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\nContent-Type: application/json\n" :-timer nil :-backend curl :-tempfiles ("/tmp/emacs-requesth7USB4"))))
  apply(apply #f(compiled-function (&rest args2) #<bytecode 0x1be7599>) (:data ((errcode . "M_MISSING_TOKEN") (error . "Missing access token.")) :symbol-status error :error-thrown (error http 401) :response #s(request-response :status-code 401 :history nil :data ((errcode . "M_MISSING_TOKEN") (error . "Missing access token.")) :error-thrown (error http 401) :symbol-status error :url "https://matrix.org/_matrix/client/r0/sync?timeout=30000&full_state=true" :done-p nil :settings (:type "GET" :params (("timeout" . "30000") ("full_state" . "true")) :parser json-read :data "null" :error #f(compiled-function (&rest args2) #<bytecode 0x1be7599>) :headers (("Content-Type" . "application/json")) :complete #f(compiled-function (&rest args2) #<bytecode 0x1becf39>) :url "https://matrix.org/_matrix/client/r0/sync?timeout=30000&full_state=true" :response #2) :-buffer #<killed buffer> :-raw-header "HTTP/1.1 401 Unauthorized\nContent-Length: 75\nAccess-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Authorization\nServer: Synapse/0.24.1 (b=matrix-org-hotfixes,7add114)\nDate: Thu, 16 Nov 2017 18:43:22 GMT\nAccess-Control-Allow-Origin: *\nAccess-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\nContent-Type: application/json\n" :-timer nil :-backend curl :-tempfiles ("/tmp/emacs-requesth7USB4"))))
  request--safe-apply(#f(compiled-function (&rest args2) #<bytecode 0x1be7599>) (:data ((errcode . "M_MISSING_TOKEN") (error . "Missing access token.")) :symbol-status error :error-thrown (error http 401) :response #s(request-response :status-code 401 :history nil :data ((errcode . "M_MISSING_TOKEN") (error . "Missing access token.")) :error-thrown (error http 401) :symbol-status error :url "https://matrix.org/_matrix/client/r0/sync?timeout=30000&full_state=true" :done-p nil :settings (:type "GET" :params (("timeout" . "30000") ("full_state" . "true")) :parser json-read :data "null" :error #f(compiled-function (&rest args2) #<bytecode 0x1be7599>) :headers (("Content-Type" . "application/json")) :complete #f(compiled-function (&rest args2) #<bytecode 0x1becf39>) :url "https://matrix.org/_matrix/client/r0/sync?timeout=30000&full_state=true" :response #2) :-buffer #<killed buffer> :-raw-header "HTTP/1.1 401 Unauthorized\nContent-Length: 75\nAccess-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Authorization\nServer: Synapse/0.24.1 (b=matrix-org-hotfixes,7add114)\nDate: Thu, 16 Nov 2017 18:43:22 GMT\nAccess-Control-Allow-Origin: *\nAccess-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\nContent-Type: application/json\n" :-timer nil :-backend curl :-tempfiles ("/tmp/emacs-requesth7USB4"))))
  request--callback(#<killed buffer> :type "GET" :params (("timeout" . "30000") ("full_state" . "true")) :parser json-read :data "null" :error #f(compiled-function (&rest args2) #<bytecode 0x1be7599>) :headers (("Content-Type" . "application/json")) :complete #f(compiled-function (&rest args2) #<bytecode 0x1becf39>) :url "https://matrix.org/_matrix/client/r0/sync?timeout=30000&full_state=true" :response #s(request-response :status-code 401 :history nil :data ((errcode . "M_MISSING_TOKEN") (error . "Missing access token.")) :error-thrown (error http 401) :symbol-status error :url "https://matrix.org/_matrix/client/r0/sync?timeout=30000&full_state=true" :done-p nil :settings (:type "GET" :params (("timeout" . "30000") ("full_state" . "true")) :parser json-read :data "null" :error #f(compiled-function (&rest args2) #<bytecode 0x1be7599>) :headers (("Content-Type" . "application/json")) :complete #f(compiled-function (&rest args2) #<bytecode 0x1becf39>) :url "https://matrix.org/_matrix/client/r0/sync?timeout=30000&full_state=true" :response #1) :-buffer #<killed buffer> :-raw-header "HTTP/1.1 401 Unauthorized\nContent-Length: 75\nAccess-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Authorization\nServer: Synapse/0.24.1 (b=matrix-org-hotfixes,7add114)\nDate: Thu, 16 Nov 2017 18:43:22 GMT\nAccess-Control-Allow-Origin: *\nAccess-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\nContent-Type: application/json\n" :-timer nil :-backend curl :-tempfiles ("/tmp/emacs-requesth7USB4")))
  apply(request--callback #<killed buffer> (:type "GET" :params (("timeout" . "30000") ("full_state" . "true")) :parser json-read :data "null" :error #f(compiled-function (&rest args2) #<bytecode 0x1be7599>) :headers (("Content-Type" . "application/json")) :complete #f(compiled-function (&rest args2) #<bytecode 0x1becf39>) :url "https://matrix.org/_matrix/client/r0/sync?timeout=30000&full_state=true" :response #s(request-response :status-code 401 :history nil :data ((errcode . "M_MISSING_TOKEN") (error . "Missing access token.")) :error-thrown (error http 401) :symbol-status error :url "https://matrix.org/_matrix/client/r0/sync?timeout=30000&full_state=true" :done-p nil :settings #1 :-buffer #<killed buffer> :-raw-header "HTTP/1.1 401 Unauthorized\nContent-Length: 75\nAccess-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Authorization\nServer: Synapse/0.24.1 (b=matrix-org-hotfixes,7add114)\nDate: Thu, 16 Nov 2017 18:43:22 GMT\nAccess-Control-Allow-Origin: *\nAccess-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\nContent-Type: application/json\n" :-timer nil :-backend curl :-tempfiles ("/tmp/emacs-requesth7USB4"))))
  request--curl-callback(#<process request curl<1>> "finished\n")
```

Which lead me to the code below.

It seemed to be getting a `'(401)` but wasn't equipped to handle it, this should fix that error.

Another red herring in here is that `string-to-int` isn't a valid function, so I don't think this function ever ran properly.