### PR TITLE
Fix error on latest emacs-26 builds

### DIFF
--- a/matrix-api.el
+++ b/matrix-api.el
@@ -168,7 +168,7 @@ will be called by `request' when the call completes"
       (funcall callback data))))
 
 (cl-defmethod matrix-send-event ((con matrix-connection) room-id event-type content
-                                 &optional &key async)
+                                 &key async)
   "Send a raw event to the room ROOM-ID.
 EVENT-TYPE is the matrix event type to send (see Matrix spec).
 CONTENT is a `json-encode' compatible list to include in the


### PR DESCRIPTION
Per https://debbugs.gnu.org/cgi/bugreport.cgi?bug=29165, it seems that support for optional followed by key or rest is going to be dropped, so I've made this tiny change. I'm not sure if it's going to stick, which is why this is a PR for now. I'll follow the bug and merge if it looks like it's finalized.

`&key` should imply `&optional`, so I think this shouldn't change anything.